### PR TITLE
Use /_health/ endpoint to avoid 302 and make it so you can choose log…

### DIFF
--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -7,15 +7,6 @@ Description: This stack deploys a Fargate cluster that is in a VPC with both
              the private subnet, which can be used for private internal traffic
              between internal services. Specificaly for Posthog <3
 Parameters:
-  StackName:
-    Type: String
-    Default: posthog
-    Description: The name of the parent Fargate networking stack that you created. Necessary
-                 to locate and reference resources created by that stack.
-  ServiceName:
-    Type: String
-    Default: posthog 
-    Description: A name for the service
   ImageUrl:
     Type: String
     Default: posthog/posthog:latest 
@@ -417,7 +408,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 60
-      HealthCheckPath: /_health
+      HealthCheckPath: /_health/
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 10 
       HealthyThresholdCount: 10
@@ -472,7 +463,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 60
-      HealthCheckPath: /_health
+      HealthCheckPath: /_health/
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 5
@@ -564,14 +555,14 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties: 
-      LogGroupName: posthog 
+      LogGroupName: !Ref 'AWS::StackName'
       RetentionInDays: 7 
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: !Ref 'ServiceName'
+      Family: !Ref 'AWS::StackName'
       Cpu: !Ref 'ContainerCpu'
       Memory: !Ref 'ContainerMemory'
       NetworkMode: awsvpc
@@ -584,7 +575,7 @@ Resources:
           - !Ref 'Role'
           - !Ref "AWS::NoValue"
       ContainerDefinitions:
-        - Name: !Ref 'ServiceName'
+        - Name: !Ref 'AWS::StackName'
           Command:
             - "./bin/docker"
           Cpu: !Ref 'ContainerCpu'
@@ -593,8 +584,8 @@ Resources:
             LogDriver: awslogs
             Options:
               awslogs-region: !Ref "AWS::Region" 
-              awslogs-group: posthog
-              awslogs-stream-prefix: posthog
+              awslogs-group: !Ref 'AWS::StackName' 
+              awslogs-stream-prefix: !Ref 'AWS::StackName' 
           Image: !Ref 'ImageUrl'
           PortMappings:
             - ContainerPort: !Ref 'ContainerPort'
@@ -651,7 +642,7 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: LoadBalancerRule
     Properties:
-      ServiceName: !Ref 'ServiceName'
+      ServiceName: !Ref 'AWS::StackName'
       Cluster: !Ref 'ECSCluster'
       LaunchType: FARGATE
       DeploymentConfiguration:
@@ -668,7 +659,7 @@ Resources:
             - !Ref 'PublicSubnetTwo'
       TaskDefinition: !Ref 'TaskDefinition'
       LoadBalancers:
-        - ContainerName: !Ref 'ServiceName'
+        - ContainerName: !Ref 'AWS::StackName'
           ContainerPort: !Ref 'ContainerPort'
           TargetGroupArn: !Ref 'TargetGroup'
 
@@ -681,12 +672,12 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 60
-      HealthCheckPath: /_health
+      HealthCheckPath: /_health/
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 10
       TargetType: ip
-      Name: !Ref 'ServiceName'
+      Name: !Ref 'AWS::StackName'
       Port: !Ref 'ContainerPort'
       Protocol: HTTP
       UnhealthyThresholdCount: 10


### PR DESCRIPTION
:crossed_fingers: fixes the issue with Django returning 302 to ELB for health check