### PR TITLE
Updated CF SECRET_KEY default to standard default

### DIFF
--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -604,7 +604,7 @@ Resources:
             - Name: ALLOWED_IP_BLOCKS
               Value: !Ref 'AllowedIpBlocks' 
             - Name: SECRET_KEY
-              Value: Oh_PLz_chANGme
+              Value: '<randomly generated secret key>'
             - Name: DISABLE_SECURE_SSL_REDIRECT
               Value: !Ref 'DisableSecureSSLRedirect'
             - Name: EMAIL_HOST


### PR DESCRIPTION
- Updated CloudFormation SECRET_KEY to the default we use across all deployments.
- Now an unchanged secret key in a CloudFormation deployment will get caught if running in production.