### PR TITLE
Add proxy configuration to CF template

### DIFF
--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -194,13 +194,6 @@ Parameters:
     AllowedValues:
       - true
       - false
-  DisableSecureSSLRedirect:
-    Description: Set this to false if you are going to be using SSL
-    Type: String
-    Default: true
-    AllowedValues:
-      - true
-      - false
   UseSecureCookies:
     Description: Set this to True if you are using SSL or TLS 
     Type: String
@@ -705,7 +698,7 @@ Resources:
             - Name: SECRET_KEY
               Value: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretKey, ':SecretString:password}}' ]]
             - Name: DISABLE_SECURE_SSL_REDIRECT
-              Value: !Ref 'DisableSecureSSLRedirect'
+              Value: false
             - Name: SECURE_COOKIES 
               Value: !Ref 'UseSecureCookies'
             - Name: EMAIL_HOST
@@ -743,7 +736,7 @@ Resources:
             - Name: SECRET_KEY
               Value: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretKey, ':SecretString:password}}' ]]
             - Name: DISABLE_SECURE_SSL_REDIRECT
-              Value: !Ref 'DisableSecureSSLRedirect'
+              Value: false
             - Name: SECURE_COOKIES 
               Value: !Ref 'UseSecureCookies'
             - Name: EMAIL_HOST

--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -40,7 +40,6 @@ Metadata:
         Parameters:
           - AllowedIpBlocks
           - AutoMinorVersionUpgrade
-          - DisableSecureSSLRedirect
           - SentryDSN
       - Label:
           default: 'AWS configuration'
@@ -698,7 +697,7 @@ Resources:
             - Name: SECRET_KEY
               Value: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretKey, ':SecretString:password}}' ]]
             - Name: DISABLE_SECURE_SSL_REDIRECT
-              Value: false
+              Value: 'false'
             - Name: SECURE_COOKIES 
               Value: !Ref 'UseSecureCookies'
             - Name: EMAIL_HOST
@@ -718,9 +717,9 @@ Resources:
             - Name: SENTRY_DSN
               Value: !Ref 'SentryDSN'
             - Name: IS_BEHIND_PROXY
-              Value: true
+              Value: 'true'
             - Name: TRUST_ALL_PROXIES
-              Value: true
+              Value: 'true'
             - Name: DEPLOYMENT
               Value: Cloudformation
         - Name: !Join ['', [ !Ref 'AWS::StackName' , '-worker' ] ]
@@ -742,7 +741,7 @@ Resources:
             - Name: SECRET_KEY
               Value: !Join ['', ['{{resolve:secretsmanager:', !Ref SecretKey, ':SecretString:password}}' ]]
             - Name: DISABLE_SECURE_SSL_REDIRECT
-              Value: false
+              Value: 'false'
             - Name: SECURE_COOKIES 
               Value: !Ref 'UseSecureCookies'
             - Name: EMAIL_HOST
@@ -762,9 +761,9 @@ Resources:
             - Name: SENTRY_DSN
               Value: !Ref 'SentryDSN'
             - Name: IS_BEHIND_PROXY
-              Value: true
+              Value: 'true'
             - Name: TRUST_ALL_PROXIES
-              Value: true
+              Value: 'true'
             - Name: DEPLOYMENT
               Value: Cloudformation
   RDSSubnetGroup:

--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -717,6 +717,12 @@ Resources:
               Value: !Ref 'DefaultFromEmail'
             - Name: SENTRY_DSN
               Value: !Ref 'SentryDSN'
+            - Name: IS_BEHIND_PROXY
+              Value: true
+            - Name: TRUST_ALL_PROXIES
+              Value: true
+            - Name: DEPLOYMENT
+              Value: Cloudformation
         - Name: !Join ['', [ !Ref 'AWS::StackName' , '-worker' ] ]
           Command: ["./bin/docker-worker"]
           LogConfiguration:
@@ -755,6 +761,10 @@ Resources:
               Value: !Ref 'DefaultFromEmail'
             - Name: SENTRY_DSN
               Value: !Ref 'SentryDSN'
+            - Name: IS_BEHIND_PROXY
+              Value: true
+            - Name: TRUST_ALL_PROXIES
+              Value: true
             - Name: DEPLOYMENT
               Value: Cloudformation
   RDSSubnetGroup:


### PR DESCRIPTION
This issue was detected from a [managed infrastructure](https://posthog.slack.com/archives/C0113360FFV/p1615771650001700) from a customer. Our CF template relies on adding an ELB in front of the ECS containers to handle requests. As the ELB essentially behaves like a proxy,

- We need to properly set the env var `IS_BEHIND_PROXY`. This was causing an issue with instances that had Google OAuth because we were passing a redirect URL to Google on an http scheme instead of https.
- `DISABLE_SECURE_SSL_REDIRECT` must always be `false` because the ELB connects to the Docker container over http. SSL redirection needs to happen at the ELB level. Note: not sure if we properly handle this in our CF template.