### PR TITLE
Bump default ContainerMemory for CloudFormation

### DIFF
--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -78,7 +78,7 @@ Parameters:
     Description: How much CPU to give the container. 1024 is 1 CPU
   ContainerMemory:
     Type: Number
-    Default: 512
+    Default: 1024
     Description: How much memory in megabytes to give the container. Valid values depend on ContainerCpu setting.
                  Read more here https://docs.aws.amazon.com/AmazonECS/latest/userguide/fargate-task-defs.html#fargate-tasks-size
   Path:


### PR DESCRIPTION
See comment here for context: https://github.com/PostHog/posthog/issues/3644#issuecomment-800448625

Unlike heroku web + plugins + celery workers all share memory
