### PR TITLE
CloudFormation - Use RDS user and password parameters for DATABASE_URL env

### DIFF
--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -689,7 +689,7 @@ Resources:
             - ContainerPort: !Ref 'ContainerPort'
           Environment:
             - Name: DATABASE_URL
-              Value: !Join ['', ['postgres://posthog:posthogadmin@', !GetAtt [PosthogDB, Endpoint.Address], ':', !GetAtt [PosthogDB, Endpoint.Port], '/posthog']]
+              Value: !Join ['', ['postgres://', !Ref 'RDSMasterUser', ':', !Ref 'RDSMasterUserPassword', '@', !GetAtt [PosthogDB, Endpoint.Address], ':', !GetAtt [PosthogDB, Endpoint.Port], '/posthog']]
             - Name: REDIS_URL
               Value: !Join ['', ['redis://', !GetAtt [ElastiCacheCluster, RedisEndpoint.Address], ':', !GetAtt [ElastiCacheCluster, RedisEndpoint.Port] ]]
             - Name: ALLOWED_IP_BLOCKS
@@ -733,7 +733,7 @@ Resources:
           Image: !Ref 'ImageUrl'
           Environment:
             - Name: DATABASE_URL
-              Value: !Join ['', ['postgres://posthog:posthogadmin@', !GetAtt [PosthogDB, Endpoint.Address], ':', !GetAtt [PosthogDB, Endpoint.Port], '/posthog']]
+              Value: !Join ['', ['postgres://', !Ref 'RDSMasterUser', ':', !Ref 'RDSMasterUserPassword', '@', !GetAtt [PosthogDB, Endpoint.Address], ':', !GetAtt [PosthogDB, Endpoint.Port], '/posthog']]
             - Name: REDIS_URL
               Value: !Join ['', ['redis://', !GetAtt [ElastiCacheCluster, RedisEndpoint.Address], ':', !GetAtt [ElastiCacheCluster, RedisEndpoint.Port] ]]
             - Name: ALLOWED_IP_BLOCKS


### PR DESCRIPTION
Solves the 503 errors when changing RDS username or password launching the CloudFormation template.

See issue [here](https://github.com/PostHog/deployment/issues/54) for more context.