### PR TITLE
AWS RDS backups & deletion protection

### DIFF
--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -30,6 +30,7 @@ Metadata:
           - RDSMasterUserPassword
           - RDSPubliclyAvailable
           - RDSRestoreDBSnapshotId
+          - RDSBackupRetentionPeriod
 
       - Label:
           default: 'CloudWatch alerts'
@@ -216,12 +217,10 @@ Parameters:
     Type: String
     NoEcho: true
     Default: posthogadmin
-
   RDSRestoreDBSnapshotId:
     Description: RDS snapshot to restore from. Read more at https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html on updating DB instances
     Type: String
     Default: ''
-
   RDSPubliclyAvailable:
     Description: Make RDS instance available on the public web. Note that changing this on an already launched stack will create a new database from scratch.
     Type: String
@@ -229,7 +228,12 @@ Parameters:
     AllowedValues:
       - true
       - false
-
+  RDSBackupRetentionPeriod:
+    Description: The number of days for which automated backups are retained. Setting to 0 will disable automated backups (not recommended). 
+    Type: Integer
+    Default: 7
+    MaxValue: 35
+    MinValue: 0
   AlertEmail:
     Description: (Optional) Email address that will receive alerts about instance status. You will receive a confirmation email after the deployment is complete, confirm it to subscribe to alerts
     Type: String
@@ -789,6 +793,7 @@ Resources:
       MasterUsername: !Ref RDSMasterUser
       MasterUserPassword: !Ref RDSMasterUserPassword
       PubliclyAccessible: !Ref RDSPubliclyAvailable
+      BackupRetentionPeriod: !Ref RDSBackupRetentionPeriod
     DeletionPolicy: Snapshot
     UpdateReplacePolicy: Snapshot
 

--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -793,6 +793,7 @@ Resources:
       MasterUsername: !Ref RDSMasterUser
       MasterUserPassword: !Ref RDSMasterUserPassword
       PubliclyAccessible: !Ref RDSPubliclyAvailable
+      DeletionProtection: true
       BackupRetentionPeriod: !Ref RDSBackupRetentionPeriod
     DeletionPolicy: Snapshot
     UpdateReplacePolicy: Snapshot

--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -28,9 +28,10 @@ Metadata:
           - RDSAllocatedStorage
           - RDSMasterUser
           - RDSMasterUserPassword
-          - RDSPubliclyAvailable
-          - RDSRestoreDBSnapshotId
           - RDSBackupRetentionPeriod
+          - RDSRestoreDBSnapshotId
+          - RDSPubliclyAvailable
+          - AllowDatabaseDeletion
 
       - Label:
           default: 'CloudWatch alerts'
@@ -234,6 +235,13 @@ Parameters:
     Default: 7
     MaxValue: 35
     MinValue: 0
+  AllowDatabaseDeletion:
+    Description: If enabled, RDS database can be deleted. You might need to turn this on when e.g. changing an existing deployment to be publicly accessible, which requires replacing the deployment.
+    Type: String
+    Default: Disabled
+    AllowedValues:
+      - Disabled
+      - Enabled
   AlertEmail:
     Description: (Optional) Email address that will receive alerts about instance status. You will receive a confirmation email after the deployment is complete, confirm it to subscribe to alerts
     Type: String
@@ -793,7 +801,7 @@ Resources:
       MasterUsername: !Ref RDSMasterUser
       MasterUserPassword: !Ref RDSMasterUserPassword
       PubliclyAccessible: !Ref RDSPubliclyAvailable
-      DeletionProtection: true
+      DeletionProtection: !If [ RDSDeletionProtection, true, !Ref 'AWS::NoValue' ]
       BackupRetentionPeriod: !Ref RDSBackupRetentionPeriod
     DeletionPolicy: Snapshot
     UpdateReplacePolicy: Snapshot
@@ -932,6 +940,7 @@ Conditions:
   IsRedis: !Equals [ !Ref CacheEngine, redis]
   HasAlarmEmail: !Not [!Equals [!Ref AlertEmail, '']]
   RestoreRDSSnapshotSelected: !Not [ !Equals [ !Ref RDSRestoreDBSnapshotId, '' ] ]
+  RDSDeletionProtection: !Equals [!Ref 'AllowDatabaseDeletion', 'Disabled']
 
 
 # These are the values output by the CloudFormation template. Be careful

--- a/aws/cloudformation/ecs/posthog.yaml
+++ b/aws/cloudformation/ecs/posthog.yaml
@@ -230,7 +230,7 @@ Parameters:
       - false
   RDSBackupRetentionPeriod:
     Description: The number of days for which automated backups are retained. Setting to 0 will disable automated backups (not recommended). 
-    Type: Integer
+    Type: Number
     Default: 7
     MaxValue: 35
     MinValue: 0


### PR DESCRIPTION
Related to https://github.com/PostHog/posthog.com/pull/1167 (see for reference), we add these parameters to better manage production databases.
- Will enable deletion protection on the RDS database by default to prevent the existing database from being accidentally deleted.
- Allows users to configure a backup retention period to have a rolling backup in case of disaster. Defaults to 7 days.
